### PR TITLE
Add support for https config URLs

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -723,11 +723,17 @@ build_configs:
         build_environment: gcc-8
         architectures:
           arm:
-            base_defconfig: 'cip://4.19.y-cip/arm/qemu_arm_defconfig'
+            <<: *arm_arch
+            extra_configs:
+              - 'cip://4.19.y-cip/arm/qemu_arm_defconfig'
           arm64:
-            base_defconfig: 'cip://4.19.y-cip/arm64/qemu_arm64_defconfig'
+            <<: *arm64_arch
+            extra_configs:
+              - 'cip://4.19.y-cip/arm64/qemu_arm64_defconfig'
           x86_64:
-            base_defconfig: 'cip://4.19.y-cip/x86/cip_qemu_defconfig'
+            <<: *x86_64_arch
+            extra_configs:
+              - 'cip://4.19.y-cip/x86/cip_qemu_defconfig'
 
   cip_4.19-rt:
     tree: cip
@@ -737,11 +743,17 @@ build_configs:
         build_environment: gcc-8
         architectures:
           arm:
-            base_defconfig: 'cip://4.19.y-cip-rt/arm/qemu_arm_defconfig'
+            <<: *arm_arch
+            extra_configs:
+              - 'cip://4.19.y-cip-rt/arm/qemu_arm_defconfig'
           arm64:
-            base_defconfig: 'cip://4.19.y-cip-rt/arm64/qemu_arm64_defconfig'
+            <<: *arm64_arch
+            extra_configs:
+              - 'cip://4.19.y-cip-rt/arm64/qemu_arm64_defconfig'
           x86_64:
-            base_defconfig: 'cip://4.19.y-cip-rt/x86/cip_qemu_defconfig'
+            <<: *x86_64_arch
+            extra_configs:
+              - 'cip://4.19.y-cip-rt/x86/cip_qemu_defconfig'
 
   clk:
     tree: clk

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -733,7 +733,7 @@ build_configs:
           x86_64:
             <<: *x86_64_arch
             extra_configs:
-              - 'cip://4.19.y-cip/x86/cip_qemu_defconfig'
+              - 'https://gitlab.com/cip-project/cip-kernel/cip-kernel-config/-/raw/master/4.19.y-cip/x86/cip_qemu_defconfig'
 
   cip_4.19-rt:
     tree: cip


### PR DESCRIPTION
Work-in-progress to add support for generic config URLs over https, using the CIP ones as a base.

Things to improve:
* converting URLs into shorter but unique names
* use regex to substitute both `/` and `:` characters with `-` in the publish_path